### PR TITLE
Use WL62 guidelines

### DIFF
--- a/Worklight_6.1.gitignore
+++ b/Worklight_6.1.gitignore
@@ -1,0 +1,42 @@
+# NOTE: This list is unofficial and may not be suitable for every project.
+# Please consider it a starting point.
+
+# Partially based on these lists:
+# http://pic.dhe.ibm.com/infocenter/wrklight/v6r1m0/index.jsp?topic=%2Fcom.ibm.worklight.dev.doc%2Fdevref%2Fr_integrating_with_source_contro.html
+
+bin
+apps/*/android/native/assets/www
+apps/*/android/native/bin
+apps/*/android/native/gen
+apps/*/blackberry*/native/gen
+apps/*/blackberry*/native/www
+apps/*/blackberry10/native/build
+apps/*/i*/native/build
+apps/*/i*/native/www
+apps/*/i*/native/cordova
+apps/*/i*/native/CordovaLib
+apps/*/i*/native/WorklightSDK
+apps/*/i*/package
+apps/*/windowsphone*/native/Bin
+apps/*/windowsphone*/native/obj
+apps/*/windowsphone*/native/www
+
+# Adapted from
+# https://github.com/github/gitignore/blob/master/Objective-C.gitignore
+
+apps/*/i*/native/build/
+apps/*/i*/native/*.pbxuser
+!apps/*/i*/native/default.pbxuser
+apps/*/i*/native/*.mode1v3
+!apps/*/i*/native/efault.mode1v3
+apps/*/i*/native/*.mode2v3
+!apps/*/i*/native/default.mode2v3
+apps/*/i*/native/*.perspectivev3
+!apps/*/i*/native/default.perspectivev3
+apps/*/i*/native/xcuserdata
+apps/*/i*/native/*.xccheckout
+apps/*/i*/native/*.moved-aside
+apps/*/i*/native/DerivedData
+apps/*/i*/native/*.hmap
+apps/*/i*/native/*.ipa
+apps/*/i*/native/*.xcuserstate

--- a/Worklight_6.2.gitignore
+++ b/Worklight_6.2.gitignore
@@ -2,7 +2,6 @@
 # Please consider it a starting point.
 
 # Partially based on these lists:
-# http://pic.dhe.ibm.com/infocenter/wrklight/v6r1m0/index.jsp?topic=%2Fcom.ibm.worklight.dev.doc%2Fdevref%2Fr_integrating_with_source_contro.html
 # http://www-01.ibm.com/support/knowledgecenter/SSZH4A_6.2.0/com.ibm.worklight.dev.doc/devref/r_integrating_with_source_contro.html?lang=en
 
 bin
@@ -13,7 +12,6 @@ apps/*/blackberry*/native/gen
 apps/*/blackberry*/native/www
 apps/*/blackberry10/native/build
 apps/*/i*/native/build
-apps/*/i*/native/cordova
 apps/*/i*/native/www
 apps/*/i*/native/CordovaLib
 apps/*/i*/native/WorklightSDK


### PR DESCRIPTION
Update to WL 6.2 comment, ignore BB10 files, ignore BB www/, ignore CordovaLib/WorklightSDK, ignore correct windowsphone8 subdir.
